### PR TITLE
fix node dependencies

### DIFF
--- a/build/configuration.js
+++ b/build/configuration.js
@@ -1,15 +1,6 @@
 /**
  * Setup and merge configuration
  */
-
-// define dependencies
-var gulp        = require('gulp'),
-    gutil       = require('gulp-util'),
-    plugins = require("gulp-load-plugins"),
-    fs = require('fs'),
-    merge       = require('merge');
-
-
 // define configuration for task usage
 var configuration = {
     scssFiles: [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "url": "ssh://git@gitlab.cms.tdintern.de:10022/wittem/docviewer.git"
   },
   "dependencies": {
-    "merge": "^1.2.0",
     "td-neos-build": "git+ssh://git@gitlab.cms.tdintern.de:10022/neos/build.git"
   },
   "license": "OSL-3.0"


### PR DESCRIPTION
Remove a vulnerable `npm` package even though this vulnerability isn't exploitable.

Ticket for internal reference: NCP-17